### PR TITLE
Add GitLab CI Configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+# Phase 3
+before_script:
+# Print status
+  - echo -e "\e[33m+------------------------+\n|   SETTING UP PROJECT   |\n+------------------------+\e[0m"
+# Install gems the Docker image may not have
+  - bundle install --jobs $(nproc) "${FLAGS[@]}"
+# Set up the test database
+  - bundle exec rake db:migrate:reset RAILS_ENV=test
+
+test:
+  script:
+# Run their unit tests, return true so that even if their unit tests fail we can continue with their other tests
+    - echo -e "\e[33m+------------------------------+\n|   RUNNING THEIR UNIT TESTS   |\n+------------------------------+\e[0m"
+    - bundle exec rake test:units || true
+# Run their controller tests, return true so that even if their controller tests fail we can continue with their other tests
+    - echo -e "\e[33m+------------------------------------+\n|   RUNNING THEIR CONTROLLER TESTS   |\n+------------------------------------+\e[0m"
+    - bundle exec rake test:functionals || true
+# Run their controller tests, return if our solution project exists then continue on to that, otherwise return minitest's exit code
+    - echo -e "\e[33m+------------------------------+\n|   RUNNING THEIR VIEW TESTS   |\n+------------------------------+\e[0m"
+    - bundle exec cucumber || [ -d /home/sol ]
+# Do the same but replacing our test cases if they exist
+    - if [ -d /home/sol ]; then echo -e "\e[33m+----------------------------+\n|   RUNNING OUR UNIT TESTS   |\n+----------------------------+\e[0m"; fi
+    - if [ -d /home/sol ]; then rm -rf ./test && cp -r /home/sol/test ./ && bundle exec rake test:units; fi
+    - if [ -d /home/sol ]; then echo -e "\e[33m+----------------------------------+\n|   RUNNING OUR CONTROLLER TESTS   |\n+----------------------------------+\e[0m"; fi
+    - if [ -d /home/sol ]; then rm -rf ./features && cp -r /home/sol/features ./ && bundle exec rake test:functionals; fi
+    - if [ -d /home/sol ]; then echo -e "\e[33m+----------------------------+\n|   running OUR view tests   |\n+----------------------------+\e[0m"; fi
+    - if [ -d /home/sol ]; then bundle exec cucumber; fi

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :test do
   gem 'email_spec', '2.1.0'
   gem 'nokogiri', '1.7.0.1'
   gem 'simplecov', '0.12.0'
+  gem 'simplecov-console'
   gem 'single_test', '0.6.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,10 @@ GEM
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-console (0.4.1)
+      ansi
+      hirb
+      simplecov
     simplecov-html (0.10.0)
     single_test (0.6.0)
       rake
@@ -300,6 +304,7 @@ DEPENDENCIES
   shoulda-matchers (= 2.8.0)
   simple_form (= 3.4.0)
   simplecov (= 0.12.0)
+  simplecov-console
   single_test (= 0.6.0)
   spring
   sqlite3

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,9 @@
 require 'simplecov'
 SimpleCov.start 'rails'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::Console,
+]
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
This PR adds the necessary updates to support autograding Phase 3 on DarkKnight.

Added the [simplecov-console gem](https://github.com/chetan/simplecov-console) which allows us to see full line coverage in the GitLab CI output. In phase 2 I gave students a test_helper.rb file that disabled the HTML coverage reports, for this phase I updated it so that it will run **both** the HTML and Console coverage reports, so students can choose whichever they prefer.

Added the `.gitlab-ci.yml` file which enables the students code repository to be graded when they push to DarkKnight. This will run unit tests, functional tests, and cucumber tests on every push. When the phase is over it will also enable us running our solution tests. Thanks to Jake Correa for the yml file.