### PR TITLE
Change occurrences of Date.today to Date.current to prevent intermittent failures

### DIFF
--- a/test/factories.rb
+++ b/test/factories.rb
@@ -13,13 +13,13 @@ FactoryGirl.define do
   factory :item_price do
     association :item
     price 1.00
-    start_date Date.today
+    start_date Date.current
     end_date nil
   end
 
   factory :purchase do
     association :item
     quantity 1
-    date Date.today
+    date Date.current
   end
 end

--- a/test/models/item_price_test.rb
+++ b/test/models/item_price_test.rb
@@ -6,7 +6,7 @@ class ItemPriceTest < ActiveSupport::TestCase
 
   # test validations with matchers
   should validate_numericality_of(:price).is_greater_than_or_equal_to(0)
-  should allow_value(Date.today).for(:start_date)
+  should allow_value(Date.current).for(:start_date)
   should allow_value(1.day.ago.to_date).for(:start_date)
   should_not allow_value(1.day.from_now.to_date).for(:start_date)
 
@@ -36,7 +36,7 @@ class ItemPriceTest < ActiveSupport::TestCase
       assert_nil @wtp3.end_date
       @change_price = FactoryGirl.create(:item_price, item: @weighted_pieces, price: 9.95)
       @wtp3.reload
-      assert_equal Date.today, @wtp3.end_date
+      assert_equal Date.current, @wtp3.end_date
     end
 
     should "have a working scope called current" do

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -6,7 +6,7 @@ class PurchaseTest < ActiveSupport::TestCase
 
   # test validations with matchers
   should validate_numericality_of(:quantity).only_integer
-  should allow_value(Date.today).for(:date)
+  should allow_value(Date.current).for(:date)
   should allow_value(1.day.ago.to_date).for(:date)
   should_not allow_value(1.day.from_now.to_date).for(:date)
 


### PR DESCRIPTION
Our tests were using Date.today in some places which causes some tests to fail
for students after 7:00pm EST because the UTC time (of Date.current) is already
at 12:00AM of the next day. This change makes it consistent so tests shouldn't
fail at what seems to be random times.
